### PR TITLE
Refresh project documentation and presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,74 @@
+<div align="center">
+
 # Argus
 
-**English** · [简体中文](README.zh-CN.md)
+### Persistent, reviewed autonomy for long-horizon research and engineering
+
+Argus coordinates specialized AI roles that can plan, execute, verify, pause,
+and resume work beyond a single model turn.
+
+[![Build](https://github.com/microsoft/ArgusAgent/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/ArgusAgent/actions/workflows/build.yml)
+[![License](https://img.shields.io/github/license/microsoft/ArgusAgent?style=flat-square)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-22.12%2B-339933?style=flat-square&logo=nodedotjs&logoColor=white)](https://nodejs.org/)
+[![arXiv](https://img.shields.io/badge/arXiv-2608.05144-b31b1b?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2608.05144)
+
+[Website](https://argusbot.cn) ·
+[Video demo](https://www.youtube.com/watch?v=i8Qy9HCboQE) ·
+[Technical report](technical_report/argus-technical-report.pdf) ·
+[Feature guide](docs/FEATURES.md) ·
+**English** / [简体中文](README.zh-CN.md)
+
+`Manager` → `Planner` → `Engineer` ⇄ `Reviewer`
+
+</div>
+
+---
 
 ## Overview
 
-Argus is an autonomous research and engineering runtime for long-horizon work. It coordinates four persistent AI roles:
+Most agents are optimized for one conversation or one coding turn. Argus is
+built for work that lasts. It persists project state, separates execution from
+judgment, and resumes from verified progress instead of starting over.
 
-- **Manager** — interprets operator intent, selects the workflow, and controls stage transitions.
-- **Planner** — decomposes the objective into executable tasks and evidence requirements.
-- **Engineer** — implements, researches, runs experiments, and produces artifacts.
-- **Reviewer** — independently checks correctness, evidence, limitations, and completion.
+| Capability | Description |
+| --- | --- |
+| **Persistent projects** | Tasks, checkpoints, decisions, skills, evidence, and runtime state survive sessions and upgrades. |
+| **Independent review** | Execution and verification remain separate; Reviewer evaluates evidence, limitations, and completion. |
+| **Four-role runtime** | Manager, Planner, Engineer, and Reviewer have explicit authority and responsibilities. |
+| **Real tool use** | Agents work through files, terminals, APIs, experiments, and inspectable artifacts. |
+| **Domain extensibility** | Verticals define domain-specific stages, tools, evidence requirements, and completion standards. |
+| **Multiple interfaces** | Operate Argus from the terminal cockpit, Web UI, desktop host, chat bridges, plugins, or HTTP APIs. |
+| **Multiple backends** | Use GitHub Copilot CLI, Codex CLI, Claude Code, OpenCode, Pi, Grok Build, Qoder, or DeepSeek Harness. |
 
-Project state, task history, checkpoints, skills, and review evidence are persisted across sessions. Argus supports GitHub Copilot CLI, OpenAI Codex CLI, Claude Code, OpenCode, and Pi backends.
+<p align="center">
+  <img src="technical_report/figures/argus_architecture.png" width="900" alt="Argus runtime architecture">
+</p>
 
-[Technical Report PDF](technical_report/argus-technical-report.pdf)
+## Runtime model
+
+| Role | Authority | Responsibility |
+| --- | --- | --- |
+| **Manager** | Control | Interprets operator intent, chooses the workflow, and owns stage transitions. |
+| **Planner** | Direction | Decomposes objectives into executable work and defines the evidence each task must produce. |
+| **Engineer** | Execution | Implements code, conducts research, runs experiments, and creates inspectable artifacts. |
+| **Reviewer** | Verification | Independently checks correctness, evidence quality, limitations, and completion. |
+
+The host persists the campaign state around these roles. A project can stop,
+resume, survive a runtime replacement, and continue from its latest verified
+position. See the [feature and runtime-flow guide](docs/FEATURES.md) for the
+state machine, role boundaries, and reliability behavior.
 
 ## Installation
 
 ### Requirements
 
 - Python 3.11 or newer
-- Node.js 22 or newer
+- Node.js 22.12 or newer
+- Git
 - One supported agent CLI with valid authentication
+
+Docker is not required for a standard installation.
 
 ### Source installation
 
@@ -35,57 +82,153 @@ python -m pip install --upgrade pip
 pip install -e .
 ```
 
-Install and authenticate one backend. For GitHub Copilot:
+Install and authenticate a backend. For GitHub Copilot CLI:
 
 ```bash
 npm install -g @github/copilot
 copilot login
+
 argus --setup --non-interactive \
   --backend copilot \
   --accept-house-rules
 argus
 ```
 
-For Pi:
-
-```bash
-npm install -g --ignore-scripts @earendil-works/pi-coding-agent
-pi  # run /login, then exit Pi after authentication
-argus --setup --non-interactive \
-  --backend pi \
-  --accept-house-rules
-argus
-```
-
-Other supported backend installers:
-
-```bash
-npm install -g @openai/codex@latest
-npm install -g @anthropic-ai/claude-code
-curl -fsSL https://opencode.ai/install | bash
-```
-
-### npm beta installation
+### npm beta
 
 ```bash
 npm install -g @github/copilot
 copilot login
 npm install -g @argusevolve/argus@beta
+
 argus --setup --non-interactive \
   --backend copilot \
   --accept-house-rules
 argus
 ```
 
-### Update a source installation
+### Supported backends
+
+| Backend | CLI | Authentication |
+| --- | --- | --- |
+| GitHub Copilot | `npm install -g @github/copilot` | `copilot login` |
+| OpenAI Codex | `npm install -g @openai/codex@latest` | `codex login` |
+| Claude Code | `npm install -g @anthropic-ai/claude-code` | Run `claude`, then `/login` |
+| Pi | `npm install -g --ignore-scripts @earendil-works/pi-coding-agent` | Run `pi`, then `/login` |
+| OpenCode | [Official installer](https://opencode.ai/docs/) | `opencode auth login` |
+| Grok Build | [Official installer](https://x.ai/cli) | `grok login` |
+| Qoder | `npm install -g @qoder-ai/qodercli` | `qodercli login` |
+| DeepSeek Harness | `npm install -g @deepseek-ai/dsh` | Configure the dsh model provider |
+
+## Using Argus
+
+```bash
+argus                                # open the terminal cockpit
+argus --web                          # open the Web UI
+argus --status                       # inspect current runtime state
+argus doctor                         # agent-assisted inspection and repair
+argus doctor --advisor none --verify # deterministic checks without a model call
+```
+
+### Terminal cockpit
+
+The default `argus` command starts a local backend when needed and opens the
+terminal cockpit. Use it to talk to Manager, follow active work, inspect
+evidence, answer operator-owned decisions, and resume projects.
+
+### Web UI
+
+```bash
+argus --web
+```
+
+The preferred local address is
+[http://127.0.0.1:8799](http://127.0.0.1:8799). Argus selects the next
+available port when necessary. For a remote server, keep the service bound to
+localhost and use an SSH tunnel:
+
+```bash
+ssh -L 8799:127.0.0.1:8799 user@server
+```
+
+### Coding-agent plugin
+
+The packaged plugin exposes Argus through MCP and host-specific skills for
+Codex and Claude Code. Installation commands and host behavior are documented
+in [`plugins/argus/README.md`](plugins/argus/README.md).
+
+### Agent-skill integration
+
+The portable
+[`argus-runtime-orchestration`](integrations/agent-skills/argus-runtime-orchestration/SKILL.md)
+skill lets another capable agent invoke Argus, monitor durable missions, handle
+`Needs you` interventions, and close work with evidence.
+
+## Project structure
+
+| Path | Description |
+| --- | --- |
+| [`argus_skill/`](argus_skill/) | Python runtime, role orchestration, verticals, tools, WebAPI, and built-in skills. |
+| [`frontend/`](frontend/) | Terminal cockpit, Web UI, shared frontend contracts, and checked-in production bundles. |
+| [`desktop/`](desktop/) | Windows Electron host and frozen-backend packaging. |
+| [`plugins/`](plugins/) | MCP plugin package and host-specific skills. |
+| [`integrations/`](integrations/) | Portable integrations for external agent environments. |
+| [`tests/`](tests/) | Runtime, contract, integration, and interface test suites. |
+| [`technical_report/`](technical_report/) | Technical report source, evidence, figures, and compiled PDF. |
+| [`docs/FEATURES.md`](docs/FEATURES.md) | Implemented features, runtime flows, and reliability scenarios. |
+
+## Technical report
+
+The repository includes the complete report package:
+
+- [Compiled PDF](technical_report/argus-technical-report.pdf)
+- [LaTeX source](technical_report/main.tex)
+- [Figures and provenance](technical_report/figures/)
+- [Public evidence package](technical_report/evidence/)
+- [arXiv:2608.05144](https://arxiv.org/abs/2608.05144)
+
+## Development
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -e ".[dev]"
+
+python -m ruff check argus_skill tests
+python -m pytest -q
+python -m build
+```
+
+Frontend development requires Node.js 22.12 or newer:
+
+```bash
+npm --prefix frontend/web ci
+npm --prefix frontend/web test
+npm --prefix frontend/web run typecheck
+
+npm --prefix frontend/tui ci
+npm --prefix frontend/tui test
+```
+
+## Updating a source installation
 
 ```bash
 cd ArgusAgent
 git pull --ff-only
 . .venv/bin/activate
 pip install -e .
-argus
+argus --version
+argus doctor --advisor none --verify
 ```
+
+## Security and support
+
+- Review the [security policy](SECURITY.md) before reporting a vulnerability.
+  Do not disclose security vulnerabilities through public GitHub issues.
+- Use [GitHub Issues](https://github.com/microsoft/ArgusAgent/issues) for bugs
+  and feature requests, following the guidance in [SUPPORT.md](SUPPORT.md).
+- Read the [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,27 +1,73 @@
+<div align="center">
+
 # Argus
 
-[English](README.md) · **简体中文**
+### 面向长周期科研与工程的持久、可审查自主运行时
+
+Argus 协调多个职责明确的 AI 角色，使复杂任务可以跨越单次模型调用持续规划、执行、
+验证、暂停与恢复。
+
+[![Build](https://github.com/microsoft/ArgusAgent/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/ArgusAgent/actions/workflows/build.yml)
+[![License](https://img.shields.io/github/license/microsoft/ArgusAgent?style=flat-square)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-22.12%2B-339933?style=flat-square&logo=nodedotjs&logoColor=white)](https://nodejs.org/)
+[![arXiv](https://img.shields.io/badge/arXiv-2608.05144-b31b1b?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2608.05144)
+
+[官方网站](https://argusbot.cn) ·
+[视频演示](https://www.youtube.com/watch?v=i8Qy9HCboQE) ·
+[技术报告](technical_report/argus-technical-report.pdf) ·
+[功能说明](docs/FEATURES.md) ·
+[English](README.md) / **简体中文**
+
+`Manager` → `Planner` → `Engineer` ⇄ `Reviewer`
+
+</div>
+
+---
 
 ## 项目简介
 
-Argus 面向长周期任务的自主科研与工程运行时，由四个持续协作的 AI 角色组成：
+大多数 Agent 面向一次对话或一次编码回合设计。Argus 面向真正需要持续推进的任务：
+它持久化项目状态，将执行与判断分离，并从已经验证的进展继续工作，而不是每次重新
+开始。
 
-- **Manager**：理解 operator 意图、选择工作流并控制阶段迁移。
-- **Planner**：把目标拆解为可执行任务和证据要求。
-- **Engineer**：实现代码、开展调研和实验并生成产物。
-- **Reviewer**：独立检查正确性、证据、局限和完成状态。
+| 核心能力 | 说明 |
+| --- | --- |
+| **持久项目** | 任务、检查点、决策、Skill、证据与运行状态可跨 Session 和版本升级保留。 |
+| **独立审查** | 执行与验证相互分离；Reviewer 独立检查证据、局限与完成状态。 |
+| **四角色运行时** | Manager、Planner、Engineer 和 Reviewer 拥有明确的权威边界与职责。 |
+| **真实工具调用** | Agent 直接操作文件、终端、API、实验和可检查产物。 |
+| **领域扩展** | Vertical 可定义领域专属阶段、工具、证据要求与完成标准。 |
+| **多种交互界面** | 支持终端座舱、Web UI、桌面宿主、聊天桥接、插件和 HTTP API。 |
+| **多种后端** | 支持 GitHub Copilot CLI、Codex CLI、Claude Code、OpenCode、Pi、Grok Build、Qoder 与 DeepSeek Harness。 |
 
-项目状态、任务历史、检查点、Skill 与审查证据会跨 session 持久化。Argus 支持 GitHub Copilot CLI、OpenAI Codex CLI、Claude Code、OpenCode 与 Pi 后端。
+<p align="center">
+  <img src="technical_report/figures/argus_architecture.png" width="900" alt="Argus 运行时架构">
+</p>
 
-[Technical Report PDF](technical_report/argus-technical-report.pdf)
+## 运行模型
 
-## 安装方法
+| 角色 | 权威 | 职责 |
+| --- | --- | --- |
+| **Manager** | 控制 | 理解 operator 意图、选择工作流，并管理阶段迁移。 |
+| **Planner** | 方向 | 把目标拆分为可执行任务，并定义每项任务必须产出的证据。 |
+| **Engineer** | 执行 | 实现代码、开展调研、运行实验，并生成可检查产物。 |
+| **Reviewer** | 验证 | 独立检查正确性、证据质量、局限与完成状态。 |
+
+Host 在四个角色之外持久化 campaign 状态。项目可以停止、恢复、跨运行时替换，并从
+最近一次已验证位置继续推进。完整状态机、角色边界与可靠性行为见
+[功能与运行流程说明](docs/FEATURES.md)。
+
+## 安装
 
 ### 环境要求
 
 - Python 3.11 或更高版本
-- Node.js 22 或更高版本
-- 至少安装并登录一个受支持的 agent CLI
+- Node.js 22.12 或更高版本
+- Git
+- 至少一个已完成鉴权的受支持 Agent CLI
+
+普通安装不需要 Docker。
 
 ### 源码安装
 
@@ -35,54 +81,171 @@ python -m pip install --upgrade pip
 pip install -e .
 ```
 
-安装并登录一个后端。使用 GitHub Copilot：
+安装并登录一个后端。以 GitHub Copilot CLI 为例：
 
 ```bash
 npm install -g @github/copilot
 copilot login
+
 argus --setup --non-interactive \
   --backend copilot \
   --accept-house-rules
 argus
 ```
 
-使用 Pi：
-
-```bash
-npm install -g --ignore-scripts @earendil-works/pi-coding-agent
-pi  # 执行 /login，完成鉴权后退出 Pi
-argus --setup --non-interactive \
-  --backend pi \
-  --accept-house-rules
-argus
-```
-
-其他受支持后端的安装命令：
-
-```bash
-npm install -g @openai/codex@latest
-npm install -g @anthropic-ai/claude-code
-curl -fsSL https://opencode.ai/install | bash
-```
-
-### npm beta 安装
+### npm beta
 
 ```bash
 npm install -g @github/copilot
 copilot login
 npm install -g @argusevolve/argus@beta
+
 argus --setup --non-interactive \
   --backend copilot \
   --accept-house-rules
 argus
 ```
 
-### 更新源码安装
+### 支持的后端
+
+| 后端 | CLI 安装 | 鉴权 |
+| --- | --- | --- |
+| GitHub Copilot | `npm install -g @github/copilot` | `copilot login` |
+| OpenAI Codex | `npm install -g @openai/codex@latest` | `codex login` |
+| Claude Code | `npm install -g @anthropic-ai/claude-code` | 运行 `claude`，再执行 `/login` |
+| Pi | `npm install -g --ignore-scripts @earendil-works/pi-coding-agent` | 运行 `pi`，再执行 `/login` |
+| OpenCode | [官方安装说明](https://opencode.ai/docs/) | `opencode auth login` |
+| Grok Build | [官方安装说明](https://x.ai/cli) | `grok login` |
+| Qoder | `npm install -g @qoder-ai/qodercli` | `qodercli login` |
+| DeepSeek Harness | `npm install -g @deepseek-ai/dsh` | 配置 dsh 模型 Provider |
+
+## 使用 Argus
+
+```bash
+argus                                # 打开终端座舱
+argus --web                          # 打开 Web UI
+argus --status                       # 查看当前运行状态
+argus doctor                         # 调用 Agent 检查并修复
+argus doctor --advisor none --verify # 不调用模型的确定性检查
+```
+
+### 终端座舱
+
+默认的 `argus` 命令会按需启动本地后端并打开终端座舱。你可以在其中与 Manager
+对话、跟踪正在进行的工作、检查证据、回答仅由 operator 决定的问题并恢复项目。
+
+### Web UI
+
+```bash
+argus --web
+```
+
+首选本地地址为 [http://127.0.0.1:8799](http://127.0.0.1:8799)；端口被占用时
+Argus 会选择下一个可用端口。在远程服务器上，建议只监听 localhost 并使用 SSH
+隧道：
+
+```bash
+ssh -L 8799:127.0.0.1:8799 user@server
+```
+
+### Code Agent 插件
+
+仓库中的插件通过 MCP 和宿主专用 Skill 向 Codex 与 Claude Code 暴露 Argus。
+安装命令和宿主行为见
+[`plugins/argus/README.md`](plugins/argus/README.md)。
+
+### Agent Skill 集成
+
+可移植的
+[`argus-runtime-orchestration`](integrations/agent-skills/argus-runtime-orchestration/SKILL.md)
+Skill 允许其他具备工具能力的 Agent 调用 Argus、监控持久任务、处理 `Needs you`
+干预并基于证据完成收尾。
+
+## 项目结构
+
+| 路径 | 说明 |
+| --- | --- |
+| [`argus_skill/`](argus_skill/) | Python 运行时、角色编排、Vertical、工具、WebAPI 与内置 Skill。 |
+| [`frontend/`](frontend/) | 终端座舱、Web UI、共享前端协议与已构建生产 Bundle。 |
+| [`desktop/`](desktop/) | Windows Electron 宿主与冻结后端打包。 |
+| [`plugins/`](plugins/) | MCP 插件包与宿主专用 Skill。 |
+| [`integrations/`](integrations/) | 面向外部 Agent 环境的可移植集成。 |
+| [`tests/`](tests/) | 运行时、协议、集成与界面测试。 |
+| [`technical_report/`](technical_report/) | 技术报告源码、证据、图表与编译后的 PDF。 |
+| [`docs/FEATURES.md`](docs/FEATURES.md) | 已实现功能、运行流程与可靠性场景。 |
+
+## 技术报告
+
+仓库包含完整的报告材料：
+
+- [编译后的 PDF](technical_report/argus-technical-report.pdf)
+- [LaTeX 源码](technical_report/main.tex)
+- [图表与来源记录](technical_report/figures/)
+- [公开证据包](technical_report/evidence/)
+- [arXiv:2608.05144](https://arxiv.org/abs/2608.05144)
+
+## 开发
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -e ".[dev]"
+
+python -m ruff check argus_skill tests
+python -m pytest -q
+python -m build
+```
+
+前端开发需要 Node.js 22.12 或更高版本：
+
+```bash
+npm --prefix frontend/web ci
+npm --prefix frontend/web test
+npm --prefix frontend/web run typecheck
+
+npm --prefix frontend/tui ci
+npm --prefix frontend/tui test
+```
+
+## 更新源码安装
 
 ```bash
 cd ArgusAgent
 git pull --ff-only
 . .venv/bin/activate
 pip install -e .
-argus
+argus --version
+argus doctor --advisor none --verify
 ```
+
+## 安全与支持
+
+- 报告漏洞前请阅读[安全策略](SECURITY.md)，不要通过公开 GitHub Issue 披露安全漏洞。
+- Bug 与功能请求请使用
+  [GitHub Issues](https://github.com/microsoft/ArgusAgent/issues)，并遵循
+  [SUPPORT.md](SUPPORT.md) 中的说明。
+- 参与社区前请阅读[行为准则](CODE_OF_CONDUCT.md)。
+
+## 参与贡献
+
+本项目欢迎贡献与建议。大多数贡献者需要签署 Microsoft Contributor License
+Agreement（CLA），声明你有权授予 Microsoft 使用该贡献所需的权利。详细信息见
+[Microsoft CLA](https://cla.opensource.microsoft.com/)。
+
+提交 Pull Request 后，CLA Bot 会自动检查是否需要签署，并在 PR 中给出提示。
+对于使用 Microsoft CLA 的仓库，通常只需签署一次。
+
+本项目遵循
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)。
+更多信息见
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)，
+或联系 [opencode@microsoft.com](mailto:opencode@microsoft.com)。
+
+## 商标
+
+本项目可能包含项目、产品或服务的商标或 Logo。Microsoft 商标或 Logo 的授权使用
+必须遵循
+[Microsoft Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general)。
+修改版本不得造成混淆或暗示 Microsoft 提供赞助。第三方商标与 Logo 的使用应遵循
+对应第三方的政策。


### PR DESCRIPTION
## Summary
- redesign the English and Simplified Chinese READMEs around the current Argus runtime
- document capabilities, roles, backends, interfaces, repository structure, technical report, and development workflow
- preserve Microsoft CLA, Code of Conduct, security, support, and trademark guidance

## Repository metadata
- add an About description and project homepage
- add discoverability topics for agents, research, engineering, and supported backends

## Validation
- verify all local README links and image targets
- run the README installation-contract test