### PR TITLE
Mirror the public Argus README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 <div align="center">
 
-# Argus
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/brand/svg/argus-logo-horizontal-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/brand/svg/argus-logo-horizontal.svg">
+  <img src="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/brand/svg/argus-logo-horizontal.svg" width="420" alt="Argus">
+</picture>
 
-### Persistent, reviewed autonomy for long-horizon research and engineering
+### Persistent, reviewed autonomy for research and engineering
 
-Argus coordinates specialized AI roles that can plan, execute, verify, pause,
-and resume work beyond a single model turn.
+Long-running agent work that can plan, execute, verify, pause, and continue beyond a single model turn.
 
-[![Build](https://github.com/microsoft/ArgusAgent/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/ArgusAgent/actions/workflows/build.yml)
+**Preview v0.1.2 · Official Microsoft open-source preview.**
+
+[![GitHub Stars](https://img.shields.io/github/stars/microsoft/ArgusAgent?style=flat-square)](https://github.com/microsoft/ArgusAgent/stargazers)
 [![License](https://img.shields.io/github/license/microsoft/ArgusAgent?style=flat-square)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
-[![Node.js](https://img.shields.io/badge/Node.js-22.12%2B-339933?style=flat-square&logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![arXiv](https://img.shields.io/badge/arXiv-2608.05144-b31b1b?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2608.05144)
 
-[Website](https://argusbot.cn) ·
-[Video demo](https://www.youtube.com/watch?v=i8Qy9HCboQE) ·
-[Technical report](technical_report/argus-technical-report.pdf) ·
-[Feature guide](docs/FEATURES.md) ·
-**English** / [简体中文](README.zh-CN.md)
+[Website](https://argusbot.cn) · [Video Demo](https://www.youtube.com/watch?v=i8Qy9HCboQE) · [Technical Report · arXiv:2608.05144](technical_report/argus-technical-report.pdf) · [WeChat Community](#wechat-community) · **English** / [简体中文](README.zh-CN.md)
 
 `Manager` → `Planner` → `Engineer` ⇄ `Reviewer`
 
@@ -25,210 +25,480 @@ and resume work beyond a single model turn.
 
 ---
 
-## Overview
+## What is Argus?
 
-Most agents are optimized for one conversation or one coding turn. Argus is
-built for work that lasts. It persists project state, separates execution from
-judgment, and resumes from verified progress instead of starting over.
+Most agents are optimized for one conversation or one coding turn. Argus is built for work that lasts: it keeps state, separates execution from judgment, and resumes from verified progress instead of starting over.
 
-| Capability | Description |
-| --- | --- |
-| **Persistent projects** | Tasks, checkpoints, decisions, skills, evidence, and runtime state survive sessions and upgrades. |
-| **Independent review** | Execution and verification remain separate; Reviewer evaluates evidence, limitations, and completion. |
-| **Four-role runtime** | Manager, Planner, Engineer, and Reviewer have explicit authority and responsibilities. |
-| **Real tool use** | Agents work through files, terminals, APIs, experiments, and inspectable artifacts. |
-| **Domain extensibility** | Verticals define domain-specific stages, tools, evidence requirements, and completion standards. |
-| **Multiple interfaces** | Operate Argus from the terminal cockpit, Web UI, desktop host, chat bridges, plugins, or HTTP APIs. |
-| **Multiple backends** | Use GitHub Copilot CLI, Codex CLI, Claude Code, OpenCode, Pi, Grok Build, Qoder, or DeepSeek Harness. |
-
-<p align="center">
-  <img src="technical_report/figures/argus_architecture.png" width="900" alt="Argus runtime architecture">
-</p>
+| Capability | What it means |
+|---|---|
+| **Persistent state** | Tasks, checkpoints, decisions, Skills, and evidence survive sessions and runtime upgrades. |
+| **Independent review** | Execution and verification stay separate; normal rounds end with a Reviewer judgment. |
+| **Four-role runtime** | Manager, Planner, Engineer, and Reviewer have distinct authority and responsibilities. |
+| **Real tool use** | Agents work through files, terminals, experiments, APIs, and inspectable artifacts. |
+| **Domain extensibility** | Verticals can define custom stages, tools, evidence requirements, and completion standards. |
+| **Multiple backends** | Run with GitHub Copilot CLI, Pi, Codex CLI, Claude Code, OpenCode, Grok Build, Qoder, or DeepSeek Harness. |
 
 ## Runtime model
 
-| Role | Authority | Responsibility |
-| --- | --- | --- |
-| **Manager** | Control | Interprets operator intent, chooses the workflow, and owns stage transitions. |
-| **Planner** | Direction | Decomposes objectives into executable work and defines the evidence each task must produce. |
-| **Engineer** | Execution | Implements code, conducts research, runs experiments, and creates inspectable artifacts. |
-| **Reviewer** | Verification | Independently checks correctness, evidence quality, limitations, and completion. |
+| | Authority | Responsibility |
+|---:|---|---|
+| `01` | **Manager · Control** | Interprets operator intent, selects the workflow, and owns stage transitions. |
+| `02` | **Planner · Direction** | Chooses the next high-value task and defines the evidence it must produce. |
+| `03` | **Engineer · Execution** | Implements, researches, runs experiments, and creates inspectable artifacts. |
+| `04` | **Reviewer · Verification** | Independently checks correctness, evidence, limitations, and completion. |
 
-The host persists the campaign state around these roles. A project can stop,
-resume, survive a runtime replacement, and continue from its latest verified
-position. See the [feature and runtime-flow guide](docs/FEATURES.md) for the
-state machine, role boundaries, and reliability behavior.
+A project can stop, resume, survive a runtime replacement, and continue from its latest verified position.
 
-## Installation
+**Native backends:** `GitHub Copilot CLI` · `Pi` · `OpenAI Codex CLI` · `Claude Code` · `OpenCode` · `Grok Build` · `Qoder` · `DeepSeek Harness`
 
-### Requirements
+**Harbor evaluation:** Harbor Framework can invoke the complete bounded Argus
+Manager/Planner/Engineer/Reviewer runtime as a custom agent. See
+**[Harbor integration](https://github.com/lbx154/Argus/blob/main/docs/harbor.md)**.
 
-- Python 3.11 or newer
-- Node.js 22.12 or newer
-- Git
-- One supported agent CLI with valid authentication
+**Coding-agent plugin:** use the packaged MCP bridge and host-specific Skills
+without changing the core runtime. See **[Plugin quick start](https://github.com/lbx154/Argus/blob/main/docs/plugin.md)**.
 
-Docker is not required for a standard installation.
+## WeChat community
 
-### Source installation
+Scan the QR code to join the Argus community. Click the image to open it at full
+size. If the printed expiry date has passed, open an Issue and ask the
+maintainers for the latest code.
+
+<p align="center">
+  <a href="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/argus-wechat-group.jpg">
+    <img src="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/argus-wechat-group.jpg" width="360" alt="Argus WeChat community QR code">
+  </a>
+</p>
+
+## Quick Install
+
+Choose the section for your operating system. Do not mix commands between
+platforms. All platforms need Node.js **22.12+** from
+[nodejs.org](https://nodejs.org/en/download) and one authenticated Agent CLI.
+Reuse the CLI you already work in; Argus does not require a separate account.
+Docker is not required for a normal Argus installation; it is only an optional
+prerequisite for the separate Harbor evaluation integration.
+
+> [!TIP]
+> **Recommended: let the Code Agent you already use install and verify Argus.**
+> Copy the prompt in the Agent-assisted section below. The manual commands remain
+> available for users who prefer to install each step themselves.
+
+| Agent CLI | Backend | Install | Authenticate |
+|---|---|---|---|
+| GitHub Copilot CLI | `copilot` | `npm install -g @github/copilot` | `copilot login` |
+| OpenAI Codex CLI | `codex` | `npm install -g @openai/codex@latest` | `codex login` |
+| Claude Code | `claude` | `npm install -g @anthropic-ai/claude-code` | Run `claude`, then `/login` |
+| Pi | `pi` | `npm install -g --ignore-scripts @earendil-works/pi-coding-agent` | Run `pi`, then `/login` |
+| OpenCode | `opencode` | [Official install](https://opencode.ai/docs/) | `opencode auth login` |
+| Grok Build | `grok` | [Official install](https://x.ai/cli) | `grok login` |
+| Qoder CLI | `qoder` | `npm install -g @qoder-ai/qodercli` | `qodercli login` |
+| DeepSeek Harness | `dsh` | `npm install -g @deepseek-ai/dsh` | Configure `DEEPSEEK_API_KEY` or the dsh Models page |
+
+The public preview is installed directly from the current GitHub archive until
+the first PyPI release is published.
+
+### Recommended: Agent-assisted installation
+
+Send this prompt to an already installed Code Agent:
+
+```text
+Read https://github.com/lbx154/Argus/blob/main/docs/agent-install.md and install
+Argus using the section for this operating system. Prefer the Agent CLI running
+this conversation as the Argus backend. Do not create a venv on Windows or
+macOS; keep the documented venv on Linux. Run setup through its real Agent-turn
+smoke test, then run `argus doctor --deep --advisor auto`. Before account login,
+sudo, or global configuration changes, explain why and wait for approval. Never
+ask me to paste a password, token, or API key into the conversation.
+```
+
+The agent follows the **[installation execution contract](https://github.com/lbx154/Argus/blob/main/docs/agent-install.md)**.
+
+### Windows 10/11 — direct pip, no virtual environment
+
+Install Python 3.11+ from [python.org](https://www.python.org/downloads/windows/)
+and select **Add Python to PATH** in the installer. Then open a new PowerShell:
+
+```powershell
+py --version
+node --version
+py -m pip install --upgrade pip
+py -m pip install --upgrade --force-reinstall "argus-skill @ https://github.com/microsoft/ArgusAgent/archive/refs/heads/main.zip"
+$Scripts = py -c "import sysconfig; print(sysconfig.get_path('scripts'))"
+$Argus = Join-Path $Scripts "argus.exe"
+if (-not (Test-Path $Argus)) { throw "Argus entry point not found at $Argus" }
+$env:Path = "$Scripts;$env:Path"
+& $Argus --version
+& $Argus --setup
+& $Argus doctor --deep --advisor auto
+& $Argus --status
+& $Argus
+```
+
+Calling `$Argus` proves setup is not accidentally using another stale
+installation. `$env:Path` also makes plain `argus` available in the current
+PowerShell. The troubleshooting section covers persistent PATH repair.
+
+`argus doctor` is an active repair command. By default it launches an installed
+Agent CLI in the real Argus directories with tools enabled, lets the Agent
+inspect and fix the machine, then reruns deterministic checks. Use
+`argus doctor --advisor none --verify` for a no-model verification.
+The active repair may take several minutes because it performs a real Agent
+turn; it is not a quick version check.
+
+Windows currently supports installation, Manager chat, pairing, Web/TUI,
+terminal-scoped daemon control, and native durable subagents. On native Windows,
+a detached worker owns direct or supervised long commands, persists registry and
+log state, and uses bounded process-tree cleanup; WSL2 remains optional rather
+than required for this path. The Windows Desktop installer is documented separately in
+**[Windows Desktop](https://github.com/lbx154/Argus/blob/main/docs/windows-desktop.md)**.
+
+### macOS — managed command install, no manual virtual environment
+
+Install [uv](https://docs.astral.sh/uv/getting-started/installation/) if needed,
+then:
 
 ```bash
-git clone https://github.com/microsoft/ArgusAgent.git
-cd ArgusAgent
+uv --version
+node --version
+uv tool install --force --python 3.12 \
+  "argus-skill @ https://github.com/microsoft/ArgusAgent/archive/refs/heads/main.zip"
+ARGUS_BIN="$(uv tool dir --bin)/argus"
+test -x "$ARGUS_BIN"
+"$ARGUS_BIN" --version
+uv tool update-shell
+"$ARGUS_BIN" --setup
+"$ARGUS_BIN" doctor --deep --advisor auto
+"$ARGUS_BIN" --status
+"$ARGUS_BIN"
+```
 
+`ARGUS_BIN` works immediately even when uv's tool directory was not previously
+on PATH. `uv tool update-shell` makes plain `argus` available in a new terminal.
+`uv tool` already owns the isolated environment; do not create another venv.
+
+### Linux — isolated source venv
+
+Linux servers keep an explicit venv so Python, CUDA tooling, and long-running
+process ownership remain reproducible. Install Python 3.11+, Git, Node.js
+22.12+, and your distribution's `python3-venv` package first:
+
+```bash
+git clone https://github.com/microsoft/ArgusAgent.git "$HOME/ArgusAgent"
+cd "$HOME/ArgusAgent"
 python3 -m venv .venv
-. .venv/bin/activate
-python -m pip install --upgrade pip
-pip install -e .
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -e .
+ARGUS_BIN="$HOME/ArgusAgent/.venv/bin/argus"
+"$ARGUS_BIN" --version
+"$ARGUS_BIN" --setup
+"$ARGUS_BIN" doctor --deep --advisor auto
+"$ARGUS_BIN" --status
+"$ARGUS_BIN"
 ```
 
-Install and authenticate a backend. For GitHub Copilot CLI:
+Do not rely on a globally installed `argus` on Linux. In a new shell, use
+`$HOME/ArgusAgent/.venv/bin/argus` (or activate that venv explicitly). If venv
+creation reports that `ensurepip` is unavailable, install the distribution's
+`python3-venv` package and rerun the command.
+
+### Backend notes
+
+Use `copilot`, `pi`, `codex`, `claude`, `opencode`, `grok`, `qoder`, or `dsh`
+for `--backend`. Setup adopts a model from the selected CLI's own catalog when
+one is available; otherwise it keeps that CLI's native default. It does not
+inject an OpenAI model id into Claude Code, Pi, OpenCode, Grok, Qoder, or dsh.
+If you have an OpenAI-compatible endpoint, setup installs Pi when needed and
+configures it directly:
 
 ```bash
-npm install -g @github/copilot
-copilot login
+ARGUS_SETUP_API_KEY=... argus --setup --non-interactive \
+  --api-url https://api.example.com/v1 \
+  --api-model model-id
+```
 
-argus --setup --non-interactive \
-  --backend copilot \
-  --accept-house-rules
+For Grok Build, install and authenticate the official xAI CLI first:
+
+```bash
+curl -fsSL https://x.ai/cli/install.sh | bash
+grok login
+argus --setup --non-interactive --backend grok
+```
+
+`XAI_API_KEY` is also supported for headless environments. Argus uses Grok's
+native headless JSON stream, resumes sessions by ID, and keeps role prompts out
+of process arguments.
+In PowerShell, use a backtick instead of `\` for line continuation.
+
+#### Choosing a provider on the multi-provider CLIs
+
+Pi and OpenCode are provider-agnostic fronts: which account they bill depends on
+what you authenticated them against (a native DeepSeek key, Anthropic, Azure, a
+local vLLM, a Copilot proxy). Argus passes your configured model id straight
+through, so a bare id like `deepseek-chat` is resolved by the CLI itself.
+
+Name the provider when a bare id is ambiguous or when the CLI requires it:
+
+```bash
+# Pi — only needed when two authenticated catalogs carry the same model id
+export ARGUS_SKILL_PI_PROVIDER=deepseek
+
+# OpenCode — required: `opencode run --model` only accepts provider/id
+export ARGUS_SKILL_OPENCODE_PROVIDER=deepseek
+```
+
+Both are also settable from the cockpit `/config` view, and persist across
+restarts once set there.
+
+`argus --doctor` reads the CLI's authenticated catalog and tells you when the
+configured provider is not one you hold a key for, or when a model id you
+selected is not on offer.
+
+Use `argus --config-help` to inspect each role's effective model and where it
+came from. Catalog commands are backend-specific, for example
+`pi --list-models`, `opencode auth list`, and `qodercli --list-models`.
+
+Full details, including the breaking change for Pi deployments that relied on
+the old implicit `github-copilot` prefix: **[backend providers](https://github.com/lbx154/Argus/blob/main/docs/backend-providers.md)**.
+
+### Launch
+
+Windows and macOS can use `argus` after PATH setup. On Linux, replace `argus`
+below with `$HOME/ArgusAgent/.venv/bin/argus` unless the venv is active.
+
+```bash
 argus
 ```
 
-### npm beta
-
 ```bash
-npm install -g @github/copilot
-copilot login
-npm install -g @argusevolve/argus@beta
-
-argus --setup --non-interactive \
-  --backend copilot \
-  --accept-house-rules
-argus
+argus doctor                         # Agent-driven inspection and repair
+argus doctor --advisor none --verify # deterministic verification, no model call
+argus --status                       # inspect the current runtime
 ```
 
-### Supported backends
+## Interfaces
 
-| Backend | CLI | Authentication |
-| --- | --- | --- |
-| GitHub Copilot | `npm install -g @github/copilot` | `copilot login` |
-| OpenAI Codex | `npm install -g @openai/codex@latest` | `codex login` |
-| Claude Code | `npm install -g @anthropic-ai/claude-code` | Run `claude`, then `/login` |
-| Pi | `npm install -g --ignore-scripts @earendil-works/pi-coding-agent` | Run `pi`, then `/login` |
-| OpenCode | [Official installer](https://opencode.ai/docs/) | `opencode auth login` |
-| Grok Build | [Official installer](https://x.ai/cli) | `grok login` |
-| Qoder | `npm install -g @qoder-ai/qodercli` | `qodercli login` |
-| DeepSeek Harness | `npm install -g @deepseek-ai/dsh` | Configure the dsh model provider |
+### Windows Desktop
 
-## Using Argus
-
-```bash
-argus                                # open the terminal cockpit
-argus --web                          # open the Web UI
-argus --status                       # inspect current runtime state
-argus doctor                         # agent-assisted inspection and repair
-argus doctor --advisor none --verify # deterministic checks without a model call
-```
+The Windows x64 source tree includes an Electron host that supervises a frozen
+copy of the same Argus runtime and opens the existing Web cockpit—there is no
+separate Desktop fork of Manager, Workbench, or the WebAPI. Source setup,
+security boundaries, verification, and packaging commands are documented in
+**[Windows Desktop](https://github.com/lbx154/Argus/blob/main/docs/windows-desktop.md)**.
 
 ### Terminal cockpit
 
-The default `argus` command starts a local backend when needed and opens the
-terminal cockpit. Use it to talk to Manager, follow active work, inspect
-evidence, answer operator-owned decisions, and resume projects.
+```bash
+argus
+```
+
+Use the terminal cockpit to talk to the Manager, follow live work, inspect state, and resume projects.
+Without an explicit `--port`, Argus reuses a compatible backend or selects the
+first available port starting at `8799` when another program or stale backend
+occupies it. On Windows, a plain `argus` launch also opens the Web UI; use
+`argus --no-open` for the terminal cockpit only.
 
 ### Web UI
+
+Start Argus and open the Web UI in your default browser:
 
 ```bash
 argus --web
 ```
 
-The preferred local address is
-[http://127.0.0.1:8799](http://127.0.0.1:8799). Argus selects the next
-available port when necessary. For a remote server, keep the service bound to
-localhost and use an SSH tunnel:
+Preferred address: [http://127.0.0.1:8799](http://127.0.0.1:8799); Argus advances
+to the next available port when needed.
+
+The Web UI follows the browser language on first launch and supports English
+and Simplified Chinese. Use the language button in the session sidebar to
+switch; the selection is saved in the browser.
+
+```bash
+argus --web --web-port 8800  # use another port
+```
+
+#### Remote server over SSH
+
+On the server:
+
+```bash
+argus --web
+```
+
+On your computer:
 
 ```bash
 ssh -L 8799:127.0.0.1:8799 user@server
 ```
 
-### Coding-agent plugin
+Then open [http://127.0.0.1:8799](http://127.0.0.1:8799) locally.
 
-The packaged plugin exposes Argus through MCP and host-specific skills for
-Codex and Claude Code. Installation commands and host behavior are documented
-in [`plugins/argus/README.md`](plugins/argus/README.md).
+<details>
+<summary><strong>Direct LAN access</strong></summary>
 
-### Agent-skill integration
-
-The portable
-[`argus-runtime-orchestration`](integrations/agent-skills/argus-runtime-orchestration/SKILL.md)
-skill lets another capable agent invoke Argus, monitor durable missions, handle
-`Needs you` interventions, and close work with evidence.
-
-## Project structure
-
-| Path | Description |
-| --- | --- |
-| [`argus_skill/`](argus_skill/) | Python runtime, role orchestration, verticals, tools, WebAPI, and built-in skills. |
-| [`frontend/`](frontend/) | Terminal cockpit, Web UI, shared frontend contracts, and checked-in production bundles. |
-| [`desktop/`](desktop/) | Windows Electron host and frozen-backend packaging. |
-| [`plugins/`](plugins/) | MCP plugin package and host-specific skills. |
-| [`integrations/`](integrations/) | Portable integrations for external agent environments. |
-| [`tests/`](tests/) | Runtime, contract, integration, and interface test suites. |
-| [`technical_report/`](technical_report/) | Technical report source, evidence, figures, and compiled PDF. |
-| [`docs/FEATURES.md`](docs/FEATURES.md) | Implemented features, runtime flows, and reliability scenarios. |
-
-## Technical report
-
-The repository includes the complete report package:
-
-- [Compiled PDF](technical_report/argus-technical-report.pdf)
-- [LaTeX source](technical_report/main.tex)
-- [Figures and provenance](technical_report/figures/)
-- [Public evidence package](technical_report/evidence/)
-- [arXiv:2608.05144](https://arxiv.org/abs/2608.05144)
-
-## Development
+A non-loopback bind is always protected by a bearer token. If
+`ARGUS_SKILL_WEB_TOKEN` is set it is used; otherwise one is minted for that run:
 
 ```bash
-python3 -m venv .venv
-. .venv/bin/activate
-python -m pip install --upgrade pip
-pip install -e ".[dev]"
-
-python -m ruff check argus_skill tests
-python -m pytest -q
-python -m build
+argus --web --web-host 0.0.0.0 --web-port 8799
 ```
 
-Frontend development requires Node.js 22.12 or newer:
+This prints the address other devices can reach, the token, and a QR code.
+Set the token yourself to keep one across restarts:
 
 ```bash
-npm --prefix frontend/web ci
-npm --prefix frontend/web test
-npm --prefix frontend/web run typecheck
-
-npm --prefix frontend/tui ci
-npm --prefix frontend/tui test
+export ARGUS_SKILL_WEB_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
 ```
 
-## Updating a source installation
+To serve without a token — only behind your own authenticating proxy — set
+`ARGUS_SKILL_WEB_ALLOW_INSECURE=1`.
+
+</details>
+
+### From a phone
+
+Telegram, Feishu/Lark, and the web UI all work from a phone. The two chat bots
+dial out, so a daemon behind NAT needs no tunnel and no public URL:
 
 ```bash
-cd ArgusAgent
-git pull --ff-only
-. .venv/bin/activate
-pip install -e .
-argus --version
-argus doctor --advisor none --verify
+# Feishu / Lark — WebSocket long connection, no request URL to configure
+pip install 'argus-skill[feishu]'
+export ARGUS_SKILL_ENABLE_FEISHU=1
+export ARGUS_SKILL_FEISHU_APP_ID=cli_xxx ARGUS_SKILL_FEISHU_APP_SECRET=xxx
+
+# Telegram
+export ARGUS_SKILL_ENABLE_TELEGRAM=1
+export ARGUS_SKILL_TELEGRAM_BOT_TOKEN=... ARGUS_SKILL_TELEGRAM_CHAT_ID=...
 ```
 
-## Security and support
+Both bots serve the same commands (`/add`, `/status`, `/nudge`, `/backlog`, …).
+The web UI is installable to the home screen and pairs by scanning the QR code
+printed by `argus --web --web-host 0.0.0.0`.
 
-- Review the [security policy](SECURITY.md) before reporting a vulnerability.
-  Do not disclose security vulnerabilities through public GitHub issues.
-- Use [GitHub Issues](https://github.com/microsoft/ArgusAgent/issues) for bugs
-  and feature requests, following the guidance in [SUPPORT.md](SUPPORT.md).
-- Read the [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
+See **[docs/mobile.md](https://github.com/lbx154/Argus/blob/main/docs/mobile.md)** for the full setup.
+
+## Advanced usage
+
+Argus is designed to be changed, not merely configured.
+
+### Autonomy level
+
+The default `pragmatic` mode handles recoverable engineering choices—timeouts, failed tests, benchmark sizing, and technical routes—without interrupting you. It asks only for credentials, more spending, irreversible/outward-facing actions, or changes to an operator-owned acceptance boundary.
+
+```bash
+export ARGUS_SKILL_AUTONOMY_MODE=cautious    # ask on every explicit question
+export ARGUS_SKILL_AUTONOMY_MODE=pragmatic   # default: recover technical issues
+export ARGUS_SKILL_AUTONOMY_MODE=autonomous  # maximize reversible execution
+```
+
+The Web configuration view and `/config` expose the same setting.
+
+### Adapt the runtime
+
+If you are an agent enthusiast, deploy Argus locally and make the complete loop fit the way you work. Tune role prompts, workflow boundaries, review policy, tools, and operating conventions; connect your own infrastructure; preserve the behavior you care about with tests.
+
+### Build your own Vertical
+
+A Vertical gives your field its own stages, Skills, datasets, tools, evidence expectations, evaluation methods, and completion criteria. Planning and review can then follow the real standards of your domain instead of a generic process.
+
+The `math` vertical is the worked example: three stages, a content-addressed
+evidence store, Lean-backed mechanical verification, and an explicit rule for
+which kind of check is allowed to settle which kind of question. See
+**[mathematical research](https://github.com/lbx154/Argus/blob/main/docs/research-mathematics.md)**.
+
+### Use another agent as the outer layer
+
+GitHub Copilot, Pi, Codex, Claude Code, OpenCode, Grok Build, OpenClaw, or Hermes can be the environment from which you invoke Argus, inspect its state, operate its local CLI or Web/API surface, and continue improving the deployment.
+
+- **Native Argus backends:** GitHub Copilot CLI, Pi, Codex CLI, Claude Code, OpenCode, Grok Build, Qoder, DeepSeek Harness
+- **External agent operators:** OpenClaw, Hermes, or any agent that can use a shell or HTTP API
+
+For durable missions, install or adapt the portable
+[`argus-runtime-orchestration` Agent Skill](integrations/agent-skills/argus-runtime-orchestration/SKILL.md).
+It defines the two-party operator model, the active `Needs you` intervention loop,
+host-specific adapters, evidence boundaries, and closeout checks.
+
+Useful entry points:
+
+```bash
+argus doctor
+argus --status
+argus --web
+```
+
+The most capable setup is often an Argus instance deliberately adapted to your own ambitious field and way of working.
+
+## Update
+
+Windows:
+
+```powershell
+py -m pip install --upgrade --force-reinstall "argus-skill @ https://github.com/microsoft/ArgusAgent/archive/refs/heads/main.zip"
+$Argus = Join-Path (py -c "import sysconfig; print(sysconfig.get_path('scripts'))") "argus.exe"
+& $Argus --version
+& $Argus doctor --advisor none --verify
+```
+
+macOS:
+
+```bash
+uv tool install --force --python 3.12 \
+  "argus-skill @ https://github.com/microsoft/ArgusAgent/archive/refs/heads/main.zip"
+"$(uv tool dir --bin)/argus" --version
+"$(uv tool dir --bin)/argus" doctor --advisor none --verify
+```
+
+Linux source checkout:
+
+```bash
+"$HOME/ArgusAgent/.venv/bin/argus" update
+"$HOME/ArgusAgent/.venv/bin/argus" --version
+"$HOME/ArgusAgent/.venv/bin/argus" doctor --advisor none --verify
+```
+
+The Linux source command refuses dirty or detached checkouts, fast-forwards the
+configured upstream, and refreshes the editable installation when the revision
+changes. Argus detects stale local WebAPI and daemon processes and replaces them
+at a controlled task boundary. Update verification is deterministic and does
+not spend a model call.
+
+## Uninstall
+
+```powershell
+# Windows
+py -m pip uninstall argus-skill
+```
+
+```bash
+# macOS
+uv tool uninstall argus-skill
+```
+
+On Linux, stop Argus, preserve any work you need, then remove the
+`$HOME/ArgusAgent` checkout and its `.venv`. Package removal intentionally leaves
+runtime state under `$HOME/.argus-skill` untouched on every platform; delete
+that directory only when you also want to remove projects, configuration, and
+logs.
+
+## Installation troubleshooting
+
+- Confirm which executable the shell is using: `Get-Command argus -All` on
+  PowerShell, or `type -a argus` on macOS/Linux. Its `argus --version` release
+  id should change after an update.
+- On macOS, use `"$(uv tool dir --bin)/argus"` immediately. Run
+  `uv tool update-shell` once and open a new terminal for plain `argus`.
+- On Windows, recover the exact Scripts directory with
+  `$Scripts = py -c "import sysconfig; print(sysconfig.get_path('scripts'))"`.
+  Add it to the current window with `$env:Path = "$Scripts;$env:Path"`. For new
+  windows, use the Python installer’s **Modify** action and enable
+  **Add Python to PATH** rather than creating a venv.
+- On Linux, use `$HOME/ArgusAgent/.venv/bin/argus`; a global `argus` may be an older
+  installation. Install `python3-venv` if `python3 -m venv` lacks `ensurepip`.
+- Use `argus doctor --advisor none --verify` for deterministic diagnostics.
+  Use `argus doctor` when you want an installed Agent to inspect and repair
+  Argus directly.
+- Use `argus --config-help` to check the effective backend/model before blaming
+  setup or authentication.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,23 +1,23 @@
 <div align="center">
 
-# Argus
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/brand/svg/argus-logo-horizontal-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/brand/svg/argus-logo-horizontal.svg">
+  <img src="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/brand/svg/argus-logo-horizontal.svg" width="420" alt="Argus">
+</picture>
 
-### 面向长周期科研与工程的持久、可审查自主运行时
+### 面向科研与工程的持久、可审查自主运行时
 
-Argus 协调多个职责明确的 AI 角色，使复杂任务可以跨越单次模型调用持续规划、执行、
-验证、暂停与恢复。
+让长期 Agent 能够规划、执行、验证、暂停，并在一次模型调用之后继续推进。
 
-[![Build](https://github.com/microsoft/ArgusAgent/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/ArgusAgent/actions/workflows/build.yml)
+**当前为 Preview v0.1.2 · Microsoft 官方开源预览版。**
+
+[![GitHub Stars](https://img.shields.io/github/stars/microsoft/ArgusAgent?style=flat-square)](https://github.com/microsoft/ArgusAgent/stargazers)
 [![License](https://img.shields.io/github/license/microsoft/ArgusAgent?style=flat-square)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
-[![Node.js](https://img.shields.io/badge/Node.js-22.12%2B-339933?style=flat-square&logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![arXiv](https://img.shields.io/badge/arXiv-2608.05144-b31b1b?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2608.05144)
 
-[官方网站](https://argusbot.cn) ·
-[视频演示](https://www.youtube.com/watch?v=i8Qy9HCboQE) ·
-[技术报告](technical_report/argus-technical-report.pdf) ·
-[功能说明](docs/FEATURES.md) ·
-[English](README.md) / **简体中文**
+[官方网站](https://argusbot.cn) · [视频演示](https://www.youtube.com/watch?v=i8Qy9HCboQE) · [技术报告 · arXiv:2608.05144](technical_report/argus-technical-report.pdf) · [微信群](#微信群) · [English](README.md) / **简体中文**
 
 `Manager` → `Planner` → `Engineer` ⇄ `Reviewer`
 
@@ -25,207 +25,446 @@ Argus 协调多个职责明确的 AI 角色，使复杂任务可以跨越单次�
 
 ---
 
-## 项目简介
+## Argus 是什么？
 
-大多数 Agent 面向一次对话或一次编码回合设计。Argus 面向真正需要持续推进的任务：
-它持久化项目状态，将执行与判断分离，并从已经验证的进展继续工作，而不是每次重新
-开始。
+大多数 Agent 面向一次对话或一次编码回合设计。Argus 面向真正需要持续推进的工作：保存状态、分离执行与判断，并从已经验证的进展继续，而不是每次重新开始。
 
-| 核心能力 | 说明 |
-| --- | --- |
-| **持久项目** | 任务、检查点、决策、Skill、证据与运行状态可跨 Session 和版本升级保留。 |
-| **独立审查** | 执行与验证相互分离；Reviewer 独立检查证据、局限与完成状态。 |
-| **四角色运行时** | Manager、Planner、Engineer 和 Reviewer 拥有明确的权威边界与职责。 |
-| **真实工具调用** | Agent 直接操作文件、终端、API、实验和可检查产物。 |
-| **领域扩展** | Vertical 可定义领域专属阶段、工具、证据要求与完成标准。 |
-| **多种交互界面** | 支持终端座舱、Web UI、桌面宿主、聊天桥接、插件和 HTTP API。 |
-| **多种后端** | 支持 GitHub Copilot CLI、Codex CLI、Claude Code、OpenCode、Pi、Grok Build、Qoder 与 DeepSeek Harness。 |
-
-<p align="center">
-  <img src="technical_report/figures/argus_architecture.png" width="900" alt="Argus 运行时架构">
-</p>
+| 核心能力 | 含义 |
+|---|---|
+| **持久状态** | 任务、检查点、决策、Skill 与证据可跨 Session 和运行时升级保存。 |
+| **独立审查** | 执行与验证相互分离；正常回合由 Reviewer 给出独立判断。 |
+| **四角色运行时** | Manager、Planner、Engineer 和 Reviewer 分别拥有明确的权威与职责。 |
+| **真实工具调用** | Agent 直接使用文件、终端、实验、API 和可检查的产物。 |
+| **领域扩展** | Vertical 可以定义专属阶段、工具、证据要求与完成标准。 |
+| **多种 Backend** | 支持 GitHub Copilot CLI、Pi、Codex CLI、Claude Code、OpenCode 与 Grok Build。 |
 
 ## 运行模型
 
-| 角色 | 权威 | 职责 |
-| --- | --- | --- |
-| **Manager** | 控制 | 理解 operator 意图、选择工作流，并管理阶段迁移。 |
-| **Planner** | 方向 | 把目标拆分为可执行任务，并定义每项任务必须产出的证据。 |
-| **Engineer** | 执行 | 实现代码、开展调研、运行实验，并生成可检查产物。 |
-| **Reviewer** | 验证 | 独立检查正确性、证据质量、局限与完成状态。 |
+| | 权威 | 职责 |
+|---:|---|---|
+| `01` | **Manager · 控制** | 理解 operator 意图、选择工作流，并独占阶段迁移权。 |
+| `02` | **Planner · 方向** | 选择下一项高价值任务，并定义它必须产出的证据。 |
+| `03` | **Engineer · 执行** | 实现代码、开展调研、运行实验，并生成可检查的产物。 |
+| `04` | **Reviewer · 验证** | 独立检查正确性、证据、局限和完成状态。 |
 
-Host 在四个角色之外持久化 campaign 状态。项目可以停止、恢复、跨运行时替换，并从
-最近一次已验证位置继续推进。完整状态机、角色边界与可靠性行为见
-[功能与运行流程说明](docs/FEATURES.md)。
+项目可以停止、恢复、跨运行时替换，并从最近一次已验证位置继续推进。
 
-## 安装
+**原生 Backend：** `GitHub Copilot CLI` · `Pi` · `OpenAI Codex CLI` · `Claude Code` · `OpenCode` · `Grok Build` · `Qoder` · `DeepSeek Harness`
 
-### 环境要求
+**Harbor 评测：** Harbor Framework 可以把完整的有界 Argus
+Manager/Planner/Engineer/Reviewer 运行时作为自定义 Agent 直接调用。配置和边界见
+**[Harbor 接入说明](https://github.com/lbx154/Argus/blob/main/docs/harbor.md)**。
 
-- Python 3.11 或更高版本
-- Node.js 22.12 或更高版本
-- Git
-- 至少一个已完成鉴权的受支持 Agent CLI
+**Code Agent 插件：** 可通过打包的 MCP bridge 和宿主 Skills 使用 Argus，不修改
+核心 runtime。参见 **[插件快速入门](https://github.com/lbx154/Argus/blob/main/docs/plugin.md)**。
 
-普通安装不需要 Docker。
+## 微信群
 
-### 源码安装
+扫码加入 Argus 交流群；点击图片可以查看原图。二维码有效期以图片中的提示为准；
+如果已经过期，请在 Issue 中联系维护者更新。
+
+<p align="center">
+  <a href="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/argus-wechat-group.jpg">
+    <img src="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/argus-wechat-group.jpg" width="360" alt="Argus 微信交流群二维码">
+  </a>
+</p>
+
+## 快速安装
+
+请只使用当前操作系统对应的一组命令，不要混用。所有平台都需要从
+[nodejs.org](https://nodejs.org/en/download) 安装 Node.js **22.12+**，并准备一个
+已完成鉴权的 Agent CLI。直接复用你日常使用的 CLI；Argus 没有单独账户。
+普通 Argus 安装不需要 Docker；只有单独的 Harbor 评测集成可能把 Docker 作为可选
+环境依赖。
+
+> [!TIP]
+> **推荐：让你正在使用的 Code Agent 代为安装并验证 Argus。**
+> 复制下面“Agent 一键安装”中的 prompt 即可；希望逐步手工安装的用户仍可使用后面的
+> 三系统命令。
+
+| Agent CLI | Backend | 安装 | 鉴权 |
+|---|---|---|---|
+| GitHub Copilot CLI | `copilot` | `npm install -g @github/copilot` | `copilot login` |
+| OpenAI Codex CLI | `codex` | `npm install -g @openai/codex@latest` | `codex login` |
+| Claude Code | `claude` | `npm install -g @anthropic-ai/claude-code` | 运行 `claude`，再执行 `/login` |
+| Pi | `pi` | `npm install -g --ignore-scripts @earendil-works/pi-coding-agent` | 运行 `pi`，再执行 `/login` |
+| OpenCode | `opencode` | [官方安装说明](https://opencode.ai/docs/) | `opencode auth login` |
+| Grok Build | `grok` | [官方安装说明](https://x.ai/cli) | `grok login` |
+| Qoder CLI | `qoder` | `npm install -g @qoder-ai/qodercli` | `qodercli login` |
+| DeepSeek Harness | `dsh` | `npm install -g @deepseek-ai/dsh` | 配置 `DEEPSEEK_API_KEY` 或 dsh Models 页面 |
+
+正式 PyPI 首发前，公共 Preview 直接从 GitHub archive 安装。
+
+### 推荐：使用 Agent 一键安装
+
+把下面整段发送给已安装的 Code Agent：
+
+```text
+请阅读 https://github.com/lbx154/Argus/blob/main/docs/agent-install.md，
+使用当前操作系统对应的方式安装 Argus。优先复用当前 Agent CLI 作为 backend。
+Windows 和 macOS 不创建手工 venv；Linux 保留文档中的 venv。必须让 setup 完成真实
+Agent turn 验收，再运行 argus doctor --deep --advisor auto。需要登录、sudo 或修改
+全局配置时先说明原因并等待确认。不要要求我在对话中粘贴密码、token 或 API Key。
+```
+
+Agent 将遵循 **[安装执行规范](https://github.com/lbx154/Argus/blob/main/docs/agent-install.md)**。
+
+### Windows 10/11：直接 pip 安装，不创建虚拟环境
+
+从 [python.org](https://www.python.org/downloads/windows/) 安装 Python 3.11+
+并勾选 **Add Python to PATH**。重新打开 PowerShell 后执行：
+
+```powershell
+py --version
+node --version
+py -m pip install --upgrade pip
+py -m pip install --upgrade --force-reinstall "argus-skill @ https://github.com/microsoft/ArgusAgent/archive/refs/heads/main.zip"
+$Scripts = py -c "import sysconfig; print(sysconfig.get_path('scripts'))"
+$Argus = Join-Path $Scripts "argus.exe"
+if (-not (Test-Path $Argus)) { throw "Argus entry point not found at $Argus" }
+$env:Path = "$Scripts;$env:Path"
+& $Argus --version
+& $Argus --setup
+& $Argus doctor --deep --advisor auto
+& $Argus --status
+& $Argus
+```
+
+使用 `$Argus` 绝对路径可以证明 setup 没有误调用旧安装。`$env:Path` 会让当前
+PowerShell 同时支持普通 `argus` 命令；新窗口的持久 PATH 修复见后面的排障章节。
+
+`argus doctor` 是主动修复命令：默认会在真实 Argus 目录中启动用户电脑上已安装的
+Agent CLI，开放工具让 Agent 直接检查并修复机器，然后重新运行确定性检查验收。
+只有需要“不调用模型的确定性验证”时才使用
+`argus doctor --advisor none --verify`。
+主动修复会执行一次真实 Agent turn，可能需要几分钟；它不是快速版本检查。
+
+Windows 当前支持安装、Manager 对话、配对、Web/TUI、终端作用域 daemon 控制和
+原生 durable subagent。Native Windows 使用独立 worker 承载 direct 或 supervised
+长命令，持久化任务注册与日志，并进行有界进程树清理；此路径不再强制依赖 WSL2。
+图形安装见 **[Windows Desktop](https://github.com/lbx154/Argus/blob/main/docs/windows-desktop.md)**。
+
+### macOS：uv tool 管理安装，不手工创建虚拟环境
+
+按需安装 [uv](https://docs.astral.sh/uv/getting-started/installation/) 后执行：
 
 ```bash
-git clone https://github.com/microsoft/ArgusAgent.git
-cd ArgusAgent
+uv --version
+node --version
+uv tool install --force --python 3.12 \
+  "argus-skill @ https://github.com/microsoft/ArgusAgent/archive/refs/heads/main.zip"
+ARGUS_BIN="$(uv tool dir --bin)/argus"
+test -x "$ARGUS_BIN"
+"$ARGUS_BIN" --version
+uv tool update-shell
+"$ARGUS_BIN" --setup
+"$ARGUS_BIN" doctor --deep --advisor auto
+"$ARGUS_BIN" --status
+"$ARGUS_BIN"
+```
 
+即使 uv 的 tool bin 尚未加入 PATH，`ARGUS_BIN` 也能立即工作。
+`uv tool update-shell` 会让新终端可以直接使用 `argus`。隔离环境已经由 uv 管理，
+不要再套一层 venv。
+
+### Linux：保留隔离源码 venv
+
+Linux 服务器继续显式使用 venv，保证 Python、CUDA 工具链和长任务进程环境可复现。
+先安装 Python 3.11+、Git、Node.js 22.12+ 和发行版的 `python3-venv` 包：
+
+```bash
+git clone https://github.com/microsoft/ArgusAgent.git "$HOME/ArgusAgent"
+cd "$HOME/ArgusAgent"
 python3 -m venv .venv
-. .venv/bin/activate
-python -m pip install --upgrade pip
-pip install -e .
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -e .
+ARGUS_BIN="$HOME/ArgusAgent/.venv/bin/argus"
+"$ARGUS_BIN" --version
+"$ARGUS_BIN" --setup
+"$ARGUS_BIN" doctor --deep --advisor auto
+"$ARGUS_BIN" --status
+"$ARGUS_BIN"
 ```
 
-安装并登录一个后端。以 GitHub Copilot CLI 为例：
+Linux 新终端不要依赖全局 `argus`；请使用
+`$HOME/ArgusAgent/.venv/bin/argus`（或显式激活该 venv）。如果创建 venv 时提示缺少
+`ensurepip`，安装发行版的 `python3-venv` 包后重试。
+
+### Backend 说明
+
+`--backend` 可使用 `copilot`、`pi`、`codex`、`claude`、`opencode`、`grok`、
+`qoder` 或 `dsh`。setup 会优先采用所选 CLI 自己目录中的模型；无法确定时保留
+该 CLI 的原生默认值，不会把 OpenAI 模型 id 注入 Claude Code、Pi、OpenCode、
+Grok、Qoder 或 dsh。
+如果已有 OpenAI-compatible URL，setup 会在需要时自动安装 Pi 并完成配置：
 
 ```bash
-npm install -g @github/copilot
-copilot login
+ARGUS_SETUP_API_KEY=... argus --setup --non-interactive \
+  --api-url https://api.example.com/v1 \
+  --api-model model-id
+```
 
-argus --setup --non-interactive \
-  --backend copilot \
-  --accept-house-rules
+使用 Grok Build 时，请先安装并登录 xAI 官方 CLI：
+
+```bash
+curl -fsSL https://x.ai/cli/install.sh | bash
+grok login
+argus --setup --non-interactive --backend grok
+```
+
+无界面环境也可以使用 `XAI_API_KEY`。Argus 通过 Grok 原生 headless JSON
+流运行、按 Session ID 续接，并避免把角色 prompt 放进进程参数。
+PowerShell 多行续行符为反引号，不是 `\`。
+
+#### 为多 provider 的 CLI 指定 provider
+
+Pi 与 OpenCode 是与 provider 无关的前端：具体走哪个账户，取决于你给它认证了什么
+（原生 DeepSeek key、Anthropic、Azure、本地 vLLM、Copilot 代理）。Argus 会把你配置
+的 model id 原样透传，因此 `deepseek-chat` 这样的裸 id 由 CLI 自己解析。
+
+只有在裸 id 有歧义、或 CLI 本身要求限定时才需要指定 provider：
+
+```bash
+# Pi —— 仅当两个已认证目录里存在同名 model 时才需要
+export ARGUS_SKILL_PI_PROVIDER=deepseek
+
+# OpenCode —— 必需：`opencode run --model` 只接受 provider/id
+export ARGUS_SKILL_OPENCODE_PROVIDER=deepseek
+```
+
+两者也可以在座舱 `/config` 里设置，在那里设置后会持久化、重启依然生效。
+
+`argus --doctor` 会读取 CLI 的已认证目录：配置的 provider 你并没有 key，或选定的
+model 不在目录中时，会直接告诉你。
+
+用 `argus --config-help` 查看每个角色最终使用的模型及配置来源。模型目录查询命令
+因 backend 而异，例如 `pi --list-models`、`opencode auth list` 和
+`qodercli --list-models`。
+
+完整说明（含对依赖旧的隐式 `github-copilot` 前缀的 Pi 部署的不兼容变更）：
+**[后端 provider 说明](https://github.com/lbx154/Argus/blob/main/docs/backend-providers.md)**。
+
+### 启动
+
+Windows 和 macOS 配好 PATH 后可直接使用 `argus`。Linux 如果没有激活 venv，
+请把下面的 `argus` 替换成 `$HOME/ArgusAgent/.venv/bin/argus`。
+
+```bash
 argus
 ```
 
-### npm beta
-
 ```bash
-npm install -g @github/copilot
-copilot login
-npm install -g @argusevolve/argus@beta
-
-argus --setup --non-interactive \
-  --backend copilot \
-  --accept-house-rules
-argus
-```
-
-### 支持的后端
-
-| 后端 | CLI 安装 | 鉴权 |
-| --- | --- | --- |
-| GitHub Copilot | `npm install -g @github/copilot` | `copilot login` |
-| OpenAI Codex | `npm install -g @openai/codex@latest` | `codex login` |
-| Claude Code | `npm install -g @anthropic-ai/claude-code` | 运行 `claude`，再执行 `/login` |
-| Pi | `npm install -g --ignore-scripts @earendil-works/pi-coding-agent` | 运行 `pi`，再执行 `/login` |
-| OpenCode | [官方安装说明](https://opencode.ai/docs/) | `opencode auth login` |
-| Grok Build | [官方安装说明](https://x.ai/cli) | `grok login` |
-| Qoder | `npm install -g @qoder-ai/qodercli` | `qodercli login` |
-| DeepSeek Harness | `npm install -g @deepseek-ai/dsh` | 配置 dsh 模型 Provider |
-
-## 使用 Argus
-
-```bash
-argus                                # 打开终端座舱
-argus --web                          # 打开 Web UI
-argus --status                       # 查看当前运行状态
 argus doctor                         # 调用 Agent 检查并修复
-argus doctor --advisor none --verify # 不调用模型的确定性检查
+argus doctor --advisor none --verify # 不调用模型的确定性验证
+argus --status                       # 查看当前运行状态
 ```
 
-### 终端座舱
+## 交互界面
 
-默认的 `argus` 命令会按需启动本地后端并打开终端座舱。你可以在其中与 Manager
-对话、跟踪正在进行的工作、检查证据、回答仅由 operator 决定的问题并恢复项目。
+### Windows Desktop
+
+Windows x64 源码包含一个 Electron 桌面宿主：它监管由同一套 Argus 运行时冻结得到的
+本地后端，并直接打开现有 Web Cockpit；Manager、Workbench 与 WebAPI 不存在单独的
+Desktop 分叉。源码运行、安全边界、验收和打包命令见
+**[Windows Desktop 文档](https://github.com/lbx154/Argus/blob/main/docs/windows-desktop.md)**。
+
+### Terminal Cockpit
+
+```bash
+argus
+```
+
+通过终端 Cockpit 与 Manager 对话、跟踪实时工作、检查状态并恢复项目。
+未显式指定 `--port` 时，Argus 会复用兼容后端；若默认端口被其他程序或旧后端占用，
+则从 `8799` 开始选择首个可用端口。在 Windows 上，普通 `argus` 启动会同时打开
+Web UI；使用 `argus --no-open` 可只保留终端 Cockpit。
 
 ### Web UI
+
+启动 Argus，并在默认浏览器中打开 Web UI：
 
 ```bash
 argus --web
 ```
 
-首选本地地址为 [http://127.0.0.1:8799](http://127.0.0.1:8799)；端口被占用时
-Argus 会选择下一个可用端口。在远程服务器上，建议只监听 localhost 并使用 SSH
-隧道：
+首选地址：[http://127.0.0.1:8799](http://127.0.0.1:8799)；被占用时会自动顺延。
+
+```bash
+argus --web --web-port 8800  # 使用其他端口
+```
+
+#### 通过 SSH 使用远程服务器
+
+在服务器上：
+
+```bash
+argus --web
+```
+
+在自己的电脑上：
 
 ```bash
 ssh -L 8799:127.0.0.1:8799 user@server
 ```
 
-### Code Agent 插件
+然后在本机打开 [http://127.0.0.1:8799](http://127.0.0.1:8799)。
 
-仓库中的插件通过 MCP 和宿主专用 Skill 向 Codex 与 Claude Code 暴露 Argus。
-安装命令和宿主行为见
-[`plugins/argus/README.md`](plugins/argus/README.md)。
+<details>
+<summary><strong>直接通过局域网访问</strong></summary>
 
-### Agent Skill 集成
-
-可移植的
-[`argus-runtime-orchestration`](integrations/agent-skills/argus-runtime-orchestration/SKILL.md)
-Skill 允许其他具备工具能力的 Agent 调用 Argus、监控持久任务、处理 `Needs you`
-干预并基于证据完成收尾。
-
-## 项目结构
-
-| 路径 | 说明 |
-| --- | --- |
-| [`argus_skill/`](argus_skill/) | Python 运行时、角色编排、Vertical、工具、WebAPI 与内置 Skill。 |
-| [`frontend/`](frontend/) | 终端座舱、Web UI、共享前端协议与已构建生产 Bundle。 |
-| [`desktop/`](desktop/) | Windows Electron 宿主与冻结后端打包。 |
-| [`plugins/`](plugins/) | MCP 插件包与宿主专用 Skill。 |
-| [`integrations/`](integrations/) | 面向外部 Agent 环境的可移植集成。 |
-| [`tests/`](tests/) | 运行时、协议、集成与界面测试。 |
-| [`technical_report/`](technical_report/) | 技术报告源码、证据、图表与编译后的 PDF。 |
-| [`docs/FEATURES.md`](docs/FEATURES.md) | 已实现功能、运行流程与可靠性场景。 |
-
-## 技术报告
-
-仓库包含完整的报告材料：
-
-- [编译后的 PDF](technical_report/argus-technical-report.pdf)
-- [LaTeX 源码](technical_report/main.tex)
-- [图表与来源记录](technical_report/figures/)
-- [公开证据包](technical_report/evidence/)
-- [arXiv:2608.05144](https://arxiv.org/abs/2608.05144)
-
-## 开发
+非本机监听始终受 Bearer Token 保护：设置了 `ARGUS_SKILL_WEB_TOKEN` 就用它，没设置则为本次运行自动生成一个。
 
 ```bash
-python3 -m venv .venv
-. .venv/bin/activate
-python -m pip install --upgrade pip
-pip install -e ".[dev]"
-
-python -m ruff check argus_skill tests
-python -m pytest -q
-python -m build
+argus --web --web-host 0.0.0.0 --web-port 8799
 ```
 
-前端开发需要 Node.js 22.12 或更高版本：
+命令会打印其他设备可达的地址、Token，以及一个二维码。想让 Token 在重启后保持不变，自己设置即可：
 
 ```bash
-npm --prefix frontend/web ci
-npm --prefix frontend/web test
-npm --prefix frontend/web run typecheck
-
-npm --prefix frontend/tui ci
-npm --prefix frontend/tui test
+export ARGUS_SKILL_WEB_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
 ```
 
-## 更新源码安装
+如果确实要在没有 Token 的情况下提供服务（仅在你自己有鉴权代理的前提下），设置 `ARGUS_SKILL_WEB_ALLOW_INSECURE=1`。
+
+</details>
+
+### 在手机上使用
+
+Telegram、飞书 / Lark 和网页版都可以在手机上使用。两个聊天机器人都是**向外拨号**的长连接，所以位于 NAT 后面的守护进程不需要内网穿透，也不需要公网地址：
 
 ```bash
-cd ArgusAgent
-git pull --ff-only
-. .venv/bin/activate
-pip install -e .
-argus --version
-argus doctor --advisor none --verify
+# 飞书 / Lark —— WebSocket 长连接，无需配置请求地址
+pip install 'argus-skill[feishu]'
+export ARGUS_SKILL_ENABLE_FEISHU=1
+export ARGUS_SKILL_FEISHU_APP_ID=cli_xxx ARGUS_SKILL_FEISHU_APP_SECRET=xxx
+
+# Telegram
+export ARGUS_SKILL_ENABLE_TELEGRAM=1
+export ARGUS_SKILL_TELEGRAM_BOT_TOKEN=... ARGUS_SKILL_TELEGRAM_CHAT_ID=...
 ```
 
-## 安全与支持
+两个机器人提供完全相同的命令（`/add`、`/status`、`/nudge`、`/backlog` 等）。网页版可以添加到手机主屏幕，扫描 `argus --web --web-host 0.0.0.0` 打印的二维码即可完成配对。
 
-- 报告漏洞前请阅读[安全策略](SECURITY.md)，不要通过公开 GitHub Issue 披露安全漏洞。
-- Bug 与功能请求请使用
-  [GitHub Issues](https://github.com/microsoft/ArgusAgent/issues)，并遵循
-  [SUPPORT.md](SUPPORT.md) 中的说明。
-- 参与社区前请阅读[行为准则](CODE_OF_CONDUCT.md)。
+完整配置见 **[docs/mobile.md](https://github.com/lbx154/Argus/blob/main/docs/mobile.md)**。
+
+## 高级使用
+
+Argus 的设计目标不是“只能配置”，而是“可以被你改变”。
+
+### 自主程度
+
+默认 `pragmatic` 模式会自行处理超时、失败测试、benchmark 规模和技术路线等可恢复问题；只有凭证、预算增加、不可逆操作、对外发布或改变你定义的验收边界时才会询问。
+
+```bash
+# 谨慎：每个明确问题都询问
+export ARGUS_SKILL_AUTONOMY_MODE=cautious
+
+# 务实（默认）：技术问题自动恢复，权威边界询问
+export ARGUS_SKILL_AUTONOMY_MODE=pragmatic
+
+# 主动：最大化可逆技术执行，仍保留凭证/金钱/不可逆边界
+export ARGUS_SKILL_AUTONOMY_MODE=autonomous
+```
+
+也可以从 Web 配置页或 `/config` 修改该选项。
+
+### 改造整个运行时
+
+如果你是 Agent 的狂热爱好者，我们推荐你在本地部署 Argus，让完整闭环真正适合自己的工作方式。你可以调整角色 Prompt、工作流边界、审查策略、工具与运行约定，对接已有基础设施，并用测试固定自己重视的行为。
+
+### 创建自己的 Vertical
+
+Vertical 可以为你的领域提供专属阶段、Skill、数据集、工具、证据要求、评测方法与完成标准。规划与审查将遵循该领域真正重要的规范，而不是一套通用流程。
+
+`math` vertical 是已实现的完整范例：三阶段流程、内容寻址的证据库、Lean 机械验证，以及"哪一类检查才有资格判定哪一类问题"的明确规则。详见 **[mathematical research](https://github.com/lbx154/Argus/blob/main/docs/research-mathematics.md)**（英文）。
+
+### 让其他 Agent 成为外层入口
+
+你可以通过 GitHub Copilot、Pi、Codex、Claude Code、OpenCode、Grok Build、OpenClaw 或 Hermes 调用 Argus、检查状态、操作本地 CLI 或 Web/API，并继续迭代自己的部署。
+
+- **Argus 原生 Backend：** GitHub Copilot CLI、Pi、Codex CLI、Claude Code、OpenCode、Grok Build、Qoder、DeepSeek Harness
+- **外层 Agent：** OpenClaw、Hermes，或任何能够使用 Shell / HTTP API 的 Agent
+
+如需运行持久任务，可安装或适配可移植的
+[`argus-runtime-orchestration` Agent Skill](integrations/agent-skills/argus-runtime-orchestration/SKILL.md)。
+该 Skill 明确定义了双方操作模型、主动检查 `Needs you` 的干预闭环、
+各宿主适配器、证据边界与收尾检查。
+
+常用入口：
+
+```bash
+argus doctor
+argus --status
+argus --web
+```
+
+最强大的 Argus 往往是一套被你认真改造成更适合自己伟大领域与工作方式的 Argus。
+
+## 更新
+
+Windows：
+
+```powershell
+py -m pip install --upgrade --force-reinstall "argus-skill @ https://github.com/microsoft/ArgusAgent/archive/refs/heads/main.zip"
+$Argus = Join-Path (py -c "import sysconfig; print(sysconfig.get_path('scripts'))") "argus.exe"
+& $Argus --version
+& $Argus doctor --advisor none --verify
+```
+
+macOS：
+
+```bash
+uv tool install --force --python 3.12 \
+  "argus-skill @ https://github.com/microsoft/ArgusAgent/archive/refs/heads/main.zip"
+"$(uv tool dir --bin)/argus" --version
+"$(uv tool dir --bin)/argus" doctor --advisor none --verify
+```
+
+Linux 源码 checkout：
+
+```bash
+"$HOME/ArgusAgent/.venv/bin/argus" update
+"$HOME/ArgusAgent/.venv/bin/argus" --version
+"$HOME/ArgusAgent/.venv/bin/argus" doctor --advisor none --verify
+```
+
+Linux 源码更新会拒绝 dirty/detached checkout，只做 fast-forward 并刷新 editable
+安装。更新后 Argus 会识别过期的本地 WebAPI 与 daemon，并在受控任务边界完成替换。
+这里的更新验收是确定性的，不消耗模型调用。
+
+## 卸载
+
+```powershell
+# Windows
+py -m pip uninstall argus-skill
+```
+
+```bash
+# macOS
+uv tool uninstall argus-skill
+```
+
+Linux 请先停止 Argus、保留所需工作，再删除 `$HOME/ArgusAgent` checkout 及其中的
+`.venv`。所有平台卸载 package 时都会保留 `$HOME/.argus-skill` 运行状态；只有在
+确定项目、配置和日志也不再需要时才删除该目录。
+
+## 安装排障
+
+- PowerShell 用 `Get-Command argus -All`，macOS/Linux 用 `type -a argus`
+  确认 shell 实际调用哪个 executable；更新后 `argus --version` 的 release id
+  应发生变化。
+- macOS 可立即使用 `"$(uv tool dir --bin)/argus"`；执行一次
+  `uv tool update-shell` 并重新打开终端后才能稳定使用普通 `argus`。
+- Windows 用
+  `$Scripts = py -c "import sysconfig; print(sysconfig.get_path('scripts'))"`
+  找回准确 Scripts 目录，再用 `$env:Path = "$Scripts;$env:Path"` 修复当前窗口。
+  新窗口请在 Python 安装器的 **Modify** 中启用 **Add Python to PATH**，不要为此
+  创建 venv。
+- Linux 使用 `$HOME/ArgusAgent/.venv/bin/argus`；全局 `argus` 可能属于旧安装。
+  `python3 -m venv` 缺少 `ensurepip` 时先安装 `python3-venv`。
+- `argus doctor --advisor none --verify` 只做确定性诊断；需要本机 Agent 直接检查和
+  修复 Argus 时使用 `argus doctor`。
+- 用 `argus --config-help` 检查实际 backend/model，再判断 setup 或鉴权是否失败。
 
 ## 参与贡献
 

--- a/tests/test_install_documentation.py
+++ b/tests/test_install_documentation.py
@@ -13,4 +13,5 @@ def test_readmes_document_the_supported_source_install() -> None:
         assert "python3 -m venv .venv" in text
         assert "pip install -e ." in text
         assert "argus --setup --non-interactive" in text
-        assert "--accept-house-rules" in text
+        assert "github.com/microsoft/ArgusAgent" in text
+        assert "argus doctor --advisor none --verify" in text


### PR DESCRIPTION
## Summary
- replace the customized README structure with the current `lbx154/Argus` English and Chinese README content
- change only Microsoft repository identity, install paths, link compatibility, and required compliance sections
- preserve links to public documentation that was intentionally excluded from this repository sync

## Validation
- compare both READMEs directly against `lbx154/Argus`
- verify every local link target
- run the README installation-contract test