### PR TITLE
docs: remove community QR codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Long-running agent work that can plan, execute, verify, pause, and continue beyo
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![arXiv](https://img.shields.io/badge/arXiv-2608.05144-b31b1b?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2608.05144)
 
-[Website](https://argusbot.cn) · [Video Demo](https://www.youtube.com/watch?v=i8Qy9HCboQE) · [Technical Report · arXiv:2608.05144](technical_report/argus-technical-report.pdf) · [WeChat Community](#wechat-community) · **English** / [简体中文](README.zh-CN.md)
+[Website](https://argusbot.cn) · [Video Demo](https://www.youtube.com/watch?v=i8Qy9HCboQE) · [Technical Report · arXiv:2608.05144](technical_report/argus-technical-report.pdf) · **English** / [简体中文](README.zh-CN.md)
 
 `Manager` → `Planner` → `Engineer` ⇄ `Reviewer`
 
@@ -64,18 +64,6 @@ Manager/Planner/Engineer/Reviewer runtime as a custom agent. See
 
 **Coding-agent plugin:** use the packaged MCP bridge and host-specific Skills
 without changing the core runtime. See **[Plugin quick start](https://github.com/lbx154/Argus/blob/main/docs/plugin.md)**.
-
-## WeChat community
-
-Scan the QR code to join the Argus community. Click the image to open it at full
-size. If the printed expiry date has passed, open an Issue and ask the
-maintainers for the latest code.
-
-<p align="center">
-  <a href="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/argus-wechat-group.jpg">
-    <img src="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/argus-wechat-group.jpg" width="360" alt="Argus WeChat community QR code">
-  </a>
-</p>
 
 ## Quick Install
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,7 +17,7 @@
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![arXiv](https://img.shields.io/badge/arXiv-2608.05144-b31b1b?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2608.05144)
 
-[官方网站](https://argusbot.cn) · [视频演示](https://www.youtube.com/watch?v=i8Qy9HCboQE) · [技术报告 · arXiv:2608.05144](technical_report/argus-technical-report.pdf) · [微信群](#微信群) · [English](README.md) / **简体中文**
+[官方网站](https://argusbot.cn) · [视频演示](https://www.youtube.com/watch?v=i8Qy9HCboQE) · [技术报告 · arXiv:2608.05144](technical_report/argus-technical-report.pdf) · [English](README.md) / **简体中文**
 
 `Manager` → `Planner` → `Engineer` ⇄ `Reviewer`
 
@@ -62,17 +62,6 @@ Manager/Planner/Engineer/Reviewer 运行时作为自定义 Agent 直接调用。
 
 **Code Agent 插件：** 可通过打包的 MCP bridge 和宿主 Skills 使用 Argus，不修改
 核心 runtime。参见 **[插件快速入门](https://github.com/lbx154/Argus/blob/main/docs/plugin.md)**。
-
-## 微信群
-
-扫码加入 Argus 交流群；点击图片可以查看原图。二维码有效期以图片中的提示为准；
-如果已经过期，请在 Issue 中联系维护者更新。
-
-<p align="center">
-  <a href="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/argus-wechat-group.jpg">
-    <img src="https://raw.githubusercontent.com/lbx154/Argus/main/docs/assets/argus-wechat-group.jpg" width="360" alt="Argus 微信交流群二维码">
-  </a>
-</p>
 
 ## 快速安装
 


### PR DESCRIPTION
Remove the WeChat community QR-code sections from both README variants.

Also removes the corresponding header navigation links so they do not point to deleted anchors.